### PR TITLE
fix(warp-theme): Fix Dropdown not opening

### DIFF
--- a/components/App/Navbar/Navbar.tsx
+++ b/components/App/Navbar/Navbar.tsx
@@ -27,10 +27,13 @@ function AppNavbar() {
 					Download
 				</label>
 				<div className='dropdown dropdown-end'>
-					<label className='btn btn-ghost btn-square m-1'>
+					<label tabIndex={0} className='btn btn-ghost btn-square m-1'>
 						<DotsVerticalIcon className='w-6 h-6' />
 					</label>
-					<ul className='dropdown-content menu p-2 mt-4 drop-shadow-md bg-base-100 rounded-box w-52'>
+					<ul
+						tabIndex={0}
+						className='dropdown-content menu p-2 mt-4 drop-shadow-md bg-base-100 rounded-box w-52'
+					>
 						<li className='menu-title'>
 							<span>General</span>
 						</li>


### PR DESCRIPTION
daisyUI requires a tabindex to be set on the dropdown elements, which were missing from an earlier commit